### PR TITLE
Missing SIMD-safe comparison in CapacitiveVoltageSourceT

### DIFF
--- a/include/chowdsp_wdf/wdft/wdft_sources.h
+++ b/include/chowdsp_wdf/wdft/wdft_sources.h
@@ -131,7 +131,7 @@ namespace wdft
         /** Sets the capacitance value of the series resistor, in Farads. */
         void setCapacitanceValue (T newC)
         {
-            if (newC == C_value)
+            if (all (newC == C_value))
                 return;
 
             C_value = newC;


### PR DESCRIPTION
In source setters, new value is compared to previous value using SMID-safe comparison using the function `all`. This feature seems to be missing for `CapacitiveVoltageSourceT` where template `T` types are directly compared with `==` which throws an error when using SIMD type:
` error: no viable conversion from 'batch_bool<float, xsimd::neon64>' to 'bool'`

Fix :
`newC == C_value`
but should be : 
`all(newC == C_value) `

